### PR TITLE
React 16.3+: replace componentWillReceiveProps with componentDidUpdate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,8 +100,8 @@ var Reader = function (_React$Component) {
       this.initiate();
     }
   }, {
-    key: 'componentWillReceiveProps',
-    value: function componentWillReceiveProps(nextProps) {
+    key: 'componentDidUpdate',
+    value: function componentDidUpdate(nextProps) {
       // React according to change in props
       var changedProps = havePropsChanged(this.props, nextProps, propsKeys);
 

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ class Reader extends React.Component {
     this.initiate()
   }
 
-  componentWillReceiveProps (nextProps) {
+  componentDidUpdate (nextProps) {
     // React according to change in props
     const changedProps = havePropsChanged(this.props, nextProps, propsKeys)
 


### PR DESCRIPTION
This fix employs `componentDidUpdate` instead of `getDerivedStateFromProps` since the previous usage of `componentWillReceiveProps` here wasn't updating state.

Here's a good explainer of the various deprecated lifecycle methods and how best to replace them: https://itnext.io/react17-or-how-to-get-rid-of-componentwillreceiveprops-c91f9a6f6f03

Same change as https://github.com/JodusNodus/react-qr-reader/pull/141
